### PR TITLE
Hotfix load_qnnli in glue_utils.py

### DIFF
--- a/data_utils/glue_utils.py
+++ b/data_utils/glue_utils.py
@@ -117,7 +117,7 @@ def load_qnnli(file, label_dict, header=True, is_train=True):
             block2 = lines[idx + 1].strip().split('\t')
             # train shuffle
             assert len(block1) > 2 and len(block2) > 2
-            if is_train and block1[1] != block2[1]:
+            if block1[1] != block2[1]:
                 mis_matched_cnt += 1
                 continue
             assert block1[1] == block2[1]

--- a/data_utils/glue_utils.py
+++ b/data_utils/glue_utils.py
@@ -110,7 +110,8 @@ def load_qnnli(file, label_dict, header=True, is_train=True):
         lines = f.readlines()
         if header: lines = lines[1:]
 
-        assert len(lines) % 2 == 0
+        if len(lines) % 2 == 0:
+            lines = lines[:-1]
         for idx in range(0, len(lines), 2):
             block1 = lines[idx].strip().split('\t')
             block2 = lines[idx + 1].strip().split('\t')


### PR DESCRIPTION
I receive two asset error on `prepro.py`. Specifically, it is in `glue_utils.py` called from `prepro.py`.
The errors are shown below. And I fixed the errors.

```
Traceback (most recent call last):
  File "prepro.py", line 352, in <module>
    main(args)
  File "prepro.py", line 193, in main
    qnnli_train_data = load_qnnli(qnli_train_path, GLOBAL_MAP['qnli'])
  File "./mt-dnn/data_utils/glue_utils.py", line 113, in load_qnnli
    assert len(lines) % 2 == 0
AssertionError
```

```
Traceback (most recent call last):
  File "prepro.py", line 352, in <module>
    main(args)
  File "prepro.py", line 195, in main
    qnnli_test_data = load_qnnli(qnli_test_path, GLOBAL_MAP['qnli'], is_train=False)
  File "./mt-dnn/data_utils/glue_utils.py", line 122, in load_qnnli
    assert block1[1] == block2[1]
AssertionError
```
