### PR TITLE
Moving model.cuda before the optimizer construction

### DIFF
--- a/mt_dnn/model.py
+++ b/mt_dnn/model.py
@@ -34,6 +34,8 @@ class MTDNNModel(object):
             self.network.load_state_dict(state_dict['state'])
         self.mnetwork = nn.DataParallel(self.network) if opt['multi_gpu_on'] else self.network
         self.total_param = sum([p.nelement() for p in self.network.parameters() if p.requires_grad])
+        if opt['cuda']:
+            self.network.cuda()
 
         no_decay = ['bias', 'gamma', 'beta', 'LayerNorm.bias', 'LayerNorm.weight']
 
@@ -86,6 +88,8 @@ class MTDNNModel(object):
         self.ema = None
         if opt['ema_opt'] > 0:
             self.ema = EMA(self.config['ema_gamma'], self.network)
+            if opt['cuda']:
+                self.ema.cuda()
         self.para_swapped=False
 
     def setup_ema(self):

--- a/train.py
+++ b/train.py
@@ -278,8 +278,6 @@ def main():
     if args.freeze_layers > 0:
         model.network.freeze_layers(args.freeze_layers)
 
-    if args.cuda:
-        model.cuda()
     for epoch in range(0, args.epochs):
         logger.warning('At epoch {}'.format(epoch))
         for train_data in train_data_list:


### PR DESCRIPTION
Current version calls ```model.cuda()``` after the optimizer construction, which may result in undesired behaviors. 

>If you need to move a model to GPU via .cuda(), please do so before constructing optimizers for it. Parameters of a model after .cuda() will be different objects with those before the call.

[Quote Source: PyTorch Doc](https://pytorch.org/docs/stable/optim.html)
