### PR TITLE
fix multi gpu bug

### DIFF
--- a/train.py
+++ b/train.py
@@ -288,12 +288,14 @@ def main():
             config = state_dict['config']
             config['attention_probs_dropout_prob'] = args.bert_dropout_p
             config['hidden_dropout_prob'] = args.bert_dropout_p
+            config['multi_gpu_on'] = opt["multi_gpu_on"]
             opt.update(config)
         else:
             logger.error('#' * 20)
             logger.error('Could not find the init model!\n The parameters will be initialized randomly!')
             logger.error('#' * 20)
             config = BertConfig(vocab_size_or_config_json_file=30522).to_dict()
+            config['multi_gpu_on'] = opt["multi_gpu_on"]
             opt.update(config)
     elif encoder_type == EncoderModelType.ROBERTA:
         bert_model_path = '{}/model.pt'.format(bert_model_path)


### PR DESCRIPTION
In previous code, command line  "multi_gpu_on" is useless since it will be overwrite by the parameter from loaded model.
Fix this bug