### PR TITLE
corrected the default value of data_dir in train.py and updated the torch version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-torch==1.2.0
+torch==1.1.0
 tqdm
 colorlog
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy
-torch==1.1.0
+torch==1.2.0
 tqdm
 colorlog
 boto3

--- a/train.py
+++ b/train.py
@@ -56,7 +56,7 @@ def data_config(parser):
     parser.add_argument('--tensorboard', action='store_true')
     parser.add_argument('--tensorboard_logdir', default='tensorboard_logdir')
     parser.add_argument("--init_checkpoint", default='mt_dnn_models/bert_model_base.pt', type=str)
-    parser.add_argument('--data_dir', default='data/canonical_data/mt_dnn_uncased_lower')
+    parser.add_argument('--data_dir', default='data/canonical_data/bert_uncased_lower')
     parser.add_argument('--data_sort_on', action='store_true')
     parser.add_argument('--name', default='farmer')
     parser.add_argument('--task_def', type=str, default="experiments/glue/glue_task_def.yml")


### PR DESCRIPTION
The default value of 'data_dir' in 'data_config' of train.py file in the master branch was 'data/canonical_data/mt_dnn_uncased_lower' which was an invalid directory location. Showing the error **"FileNotFoundError: [Errno 2] No such file or directory: 'data/canonical_data/mt_dnn_uncased_lower/mnli_train.json'"**. This is because after running the 'prepo.sh' the JSON file generated for the tasks were getting stored at 'data/canonical_data/bert_uncased_lower', So by changing the default value of 'data_dir' in 'data_config' of train.py file to 'data/canonical_data/bert_uncased_lower' the problem got fixed.

For the torch version in the master branch which was 1.1.0, at the of running the in 'requirements.txt' was giving the following error- "
ERROR: torchvision 0.4.1+cu100 has requirement torch==1.3.0, but you'll have torch 1.1.0 which is incompatible." Also,  with version **1.1.0** of torch the apex was not getting installed by the command "pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./apex"  After modifying the torch version to 1.3.0, there was the same issue of installing apex through the above command. Finally changing the torch version to **1.2.0,** fixed the apex installation problem successfully which was occurring while executing the command "pip install -v --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" ./apex". 