### PR TITLE
Support community models

### DIFF
--- a/prepro_std.py
+++ b/prepro_std.py
@@ -247,7 +247,8 @@ def main(args):
     root = args.root_dir
     assert os.path.exists(root)
 
-    literal_model_type = args.model.split('-')[0].upper()
+    model_name = args.model.split('/')[-1]
+    literal_model_type = model_name.split('-')[0].upper()
     encoder_model = EncoderModelType[literal_model_type]
     literal_model_type = literal_model_type.lower()
     mt_dnn_suffix = literal_model_type


### PR DESCRIPTION
Hello, there.

I use MT-DNN in Portuguese almost for a year and I needed to do a tiny adaptation to load community models, but I've forgot to mention here. In order find the model class, you split '-' and get the first part. So, `bert-base-uncased`, becomes `bert`.

However, for community models you need to split "/" first and get the last part: 
`neuralmind/bert-base-portuguese-cased` -> `bert-base-portuguese-cased` -> `bert`.
 
Doing this, also maintains the support for standard models as `bert-base-uncased`:
Since, I use -1 indexing: args.model.split('/')[-1]. 


 